### PR TITLE
Launcher3: Add android.permission.PACKAGE_USAGE_STATS into allowlist

### DIFF
--- a/privapp_whitelist_com.android.launcher3-ext.xml
+++ b/privapp_whitelist_com.android.launcher3-ext.xml
@@ -22,6 +22,7 @@
         <permission name="android.permission.FORCE_STOP_PACKAGES"/>
         <permission name="android.permission.MEDIA_CONTENT_CONTROL"/>
         <permission name="android.permission.GET_INTENT_SENDER_INTENT"/>
+        <permission name="android.permission.PACKAGE_USAGE_STATS"/>
         <permission name="com.android.alarm.permission.SET_ALARM"/>
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
* Otherwise some device may bootlooping

Tested on: sunfish